### PR TITLE
Clean state and add search functionality

### DIFF
--- a/app/javascript/bundles/components/Basket.tsx
+++ b/app/javascript/bundles/components/Basket.tsx
@@ -5,7 +5,7 @@ import { GroceryItem } from '.'
 interface BasketProps {
   items: GroceryListItem[];
   handleRemovedButtonPressed: (id: string) => void;
-  handleQuantityChange: (id: string, inCart: boolean, val: number) => void;
+  handleQuantityChange: (id: string, val: number) => void;
 }
 
 interface GroceryListItem {
@@ -35,7 +35,7 @@ export default class Basket extends React.Component<BasketProps> {
           quantity={item.quantity}
           inCart={true}
           handleButtonPressed={this.props.handleRemovedButtonPressed}
-          handleQuantityChange={(val): void => this.props.handleQuantityChange(item.id, false, val)} />
+          handleQuantityChange={(val): void => this.props.handleQuantityChange(item.id, val)} />
       </ListGroup.Item>
     );
 

--- a/app/javascript/bundles/components/GroceryList.tsx
+++ b/app/javascript/bundles/components/GroceryList.tsx
@@ -5,7 +5,7 @@ import { GroceryItem, NewItemModal } from '.'
 interface GroceryListProps {
   items: GroceryListItem[];
   handleAddButtonPressed: (id: string) => void;
-  handleQuantityChange: (id: string, inCart: boolean, val: number) => void;
+  handleQuantityChange: (id: string, val: number) => void;
 }
 
 interface GroceryListState {
@@ -64,7 +64,7 @@ export default class GroceryList extends React.Component<GroceryListProps, Groce
           quantity={item.quantity}
           inCart={false}
           handleButtonPressed={this.props.handleAddButtonPressed}
-          handleQuantityChange={(val): void => this.props.handleQuantityChange(item.id, false, val)}
+          handleQuantityChange={(val): void => this.props.handleQuantityChange(item.id, val)}
         />
       </ListGroup.Item>
     );


### PR DESCRIPTION
This PR cleans up the state as follows:
* Combines the `LineItemsInList` and `LineItemsInCart` to `LineItems` (where each one has a location)
* Adds a `GroceryItems` which contains the grocery items that _can_ be searched

It also then adds the ability to search.

A few things:
1. This class will still need to be cleaned up further, and broken down into components
2. It currently just passes all of the possible groceries to be loaded into the state (will likely be into the props from parent component), and then searches through them. This won't scale too well with lots of items - but will we hit lots of items?
3. I'm still not sure if the two lists should be combined. There are times I think they should and times I think they shouldn't. I'll think about it.