### PR TITLE
add fully functional new item modal

### DIFF
--- a/app/javascript/components/Groceries/Groceries.tsx
+++ b/app/javascript/components/Groceries/Groceries.tsx
@@ -54,6 +54,7 @@ class Groceries extends React.Component<RouteComponentProps, GroceriesState> {
     this.handleCartQuantityChange = this.handleCartQuantityChange.bind(this);
     this.modifyItemInList = this.modifyItemInList.bind(this);
     this.handleCreateOrder = this.handleCreateOrder.bind(this);
+    this.addNewItemToBasket = this.addNewItemToBasket.bind(this);
   }
 
   componentDidMount(): void {
@@ -168,6 +169,7 @@ class Groceries extends React.Component<RouteComponentProps, GroceriesState> {
                 items={this.state.searchLineItems}
                 handleAddButtonPressed={this.addItemToCart}
                 handleQuantityChange={this.handleListQuantityChange}
+                onAddNewItem={this.addNewItemToBasket}
               />
             </Col>
             <Col>
@@ -222,6 +224,17 @@ class Groceries extends React.Component<RouteComponentProps, GroceriesState> {
     const groceryItem = itemList.find((item) => item.id === id) as GroceryLineItem
 
     return itemList.map((item) => item.id == id ? { ...groceryItem, ...properties } : item)
+  }
+
+  addNewItemToBasket(itemName: string, itemPrice: string): void {
+    const newItem: GroceryLineItem = { name: itemName, price: Number(itemPrice), quantity: 1, id: itemName }
+    const itemAlreadyExists: boolean = this.state.cartLineItems.some((item) => item.name === itemName)
+
+    if (!itemAlreadyExists) {
+      this.setState({
+        cartLineItems: [...this.state.cartLineItems, newItem]
+      })
+    }
   }
 }
 

--- a/app/javascript/components/Groceries/components/GroceryList.tsx
+++ b/app/javascript/components/Groceries/components/GroceryList.tsx
@@ -6,6 +6,7 @@ interface GroceryListProps {
   items: GroceryListItem[];
   handleAddButtonPressed: (id: string) => void;
   handleQuantityChange: (id: string, val: number) => void;
+  onAddNewItem: (itemName: string, itemPrice: string) => void;
 }
 
 interface GroceryListState {
@@ -81,7 +82,7 @@ export default class GroceryList extends React.Component<GroceryListProps, Groce
         </ListGroup>
         <NewItemModal
           isVisible={this.state.addItemModalShowing}
-          onAdd={() => { }}
+          onAdd={this.props.onAddNewItem}
           onClose={this.hideModal}
         />
       </>

--- a/app/javascript/components/Groceries/components/NewItemModal.tsx
+++ b/app/javascript/components/Groceries/components/NewItemModal.tsx
@@ -1,65 +1,119 @@
 import React from 'react';
-import {Button, Container, Col, Row, Form, ListGroup, Modal, InputGroup, FormControl} from 'react-bootstrap';
-import {GroceryItem, GroceryList} from '.'
+import { Button, Col, Row, Modal, InputGroup, FormControl } from 'react-bootstrap';
 
 interface NewItemModalProps {
-    isVisible: boolean;
-    onAdd: () => void;
-    onClose: () => void;
+  isVisible: boolean;
+  onAdd: (itemName: string, itemPrice: string) => void;
+  onClose: () => void;
 }
 
-export default class NewItemModal extends React.Component<NewItemModalProps> {
+interface NewItemModalState {
+  itemName: string;
+  itemPrice: string;
+}
 
-  render() {
+export default class NewItemModal extends React.Component<NewItemModalProps, NewItemModalState> {
+
+  constructor(props: NewItemModalProps) {
+    super(props)
+
+    this.state = {
+      itemName: '',
+      itemPrice: ''
+    }
+
+    this.handleItemNameChange = this.handleItemNameChange.bind(this);
+    this.handleItemPriceChange = this.handleItemPriceChange.bind(this);
+    this.priceFormatted = this.priceFormatted.bind(this);
+    this.handleAddClick = this.handleAddClick.bind(this);
+
+  }
+
+  render(): JSX.Element {
 
     return (
 
-    <Modal
-      show={this.props.isVisible}
-      size="md"
-      aria-labelledby="contained-modal-title-vcenter"
-      centered
-      onHide = {this.props.onClose}
-    >
+      <Modal
+        show={this.props.isVisible}
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        onHide={this.props.onClose}
+      >
         <Modal.Header closeButton>
           <Modal.Title id="contained-modal-title-vcenter">
             Adding a new item
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-        <Row>
+          <Row>
             <Col>
-            <h5>What is the item called?</h5>
-            <InputGroup className="mb-3">
+              <h5>What is the item called?</h5>
+              <InputGroup className="mb-3">
                 <FormControl
-                    placeholder="e.g. Bananas"
-                    aria-label="name"
-                    aria-describedby="inputGroup-sizing-default"
-                  />
-            </InputGroup>
+                  placeholder="e.g. Bananas"
+                  aria-label="name"
+                  aria-describedby="inputGroup-sizing-default"
+                  value={this.state.itemName}
+                  onChange={this.handleItemNameChange}
+                />
+              </InputGroup>
             </Col>
-        </Row>
-        <Row>
+          </Row>
+          <Row>
             <Col>
-            <h5>How much are you willing to pay for it?</h5>
-            <InputGroup className='mb-3'>
+              <h5>How much are you willing to pay for it?</h5>
+              <InputGroup className='mb-3'>
                 <InputGroup.Prepend>
-                    <InputGroup.Text id="inputGroup-sizing-default">$</InputGroup.Text>
+                  <InputGroup.Text id="inputGroup-sizing-default">$</InputGroup.Text>
                 </InputGroup.Prepend>
                 <FormControl
-                    placeholder="e.g. 3.00"
-                    aria-label="price"
-                    />
-            </InputGroup>
+                  placeholder="e.g. 3.00"
+                  aria-label="price"
+                  value={this.state.itemPrice}
+                  onChange={this.handleItemPriceChange}
+                />
+              </InputGroup>
             </Col>
-            </Row>
+          </Row>
         </Modal.Body>
         <Modal.Footer>
-            <Button onClick={this.props.onAdd} variant='primary'>Add item</Button>
-            <Button onClick={this.props.onClose} variant='secondary'>Close</Button>
+          <Button
+            onClick={this.handleAddClick}
+            variant='primary'
+            disabled={this.state.itemName == '' || this.state.itemPrice == ''}
+          >
+            Add item
+          </Button>
+          <Button onClick={this.props.onClose} variant='secondary'>Close</Button>
         </Modal.Footer>
-    </Modal>
+      </Modal>
 
     );
+  }
+
+  handleItemNameChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    this.setState({ itemName: event.target.value })
+  }
+
+  handleItemPriceChange(event: React.ChangeEvent<HTMLInputElement>): void {
+    const itemPrice = event.target.value
+
+    if (this.priceFormatted(itemPrice)) {
+      this.setState({ itemPrice })
+    }
+  }
+
+  priceFormatted(input: string): boolean {
+    const num = Number(input)
+    return (!isNaN(num))
+  }
+
+  handleAddClick(): void {
+    this.props.onAdd(this.state.itemName, this.state.itemPrice)
+    this.setState({
+      itemName: '',
+      itemPrice: ''
+    })
+    this.props.onClose()
   }
 }


### PR DESCRIPTION
- add form in add new item modal being controlled by states.
- verify that the number form is a number, not more than 2dps (but it's broken, I think).
- allow new items to be added to the basket directly from the add new item modal.
- use name as the id, verify that the new item isn't being added twice.