### PR TITLE
Add support for user created groceries

### DIFF
--- a/app/controllers/api/v1/grocery_items_controller.rb
+++ b/app/controllers/api/v1/grocery_items_controller.rb
@@ -5,11 +5,36 @@ class Api::V1::GroceryItemsController < ApplicationController
   end
 
   def create
+    grocery_items = if multiple_items?
+      GroceryItem.create!(grocery_items_params[:items])
+    else
+      GroceryItem.create!(grocery_item_params)
+    end
+
+    if grocery_items
+      render json: grocery_items
+    else
+      render json: grocery_items.errors
+    end
   end
 
   def show
   end
 
   def destroy
+  end
+
+  private
+
+  def multiple_items?
+    !!params[:items]
+  end
+
+  def grocery_items_params
+    params.permit(:items => [:name, :price, :user_id])
+  end
+
+  def grocery_item_params
+    params.require([:name, :price, :user_id])
   end
 end

--- a/app/controllers/api/v1/order_line_items_controller.rb
+++ b/app/controllers/api/v1/order_line_items_controller.rb
@@ -36,6 +36,6 @@ class Api::V1::OrderLineItemsController < ApplicationController
   end
 
   def order_line_item_params
-    params.require([:quantity, :price, :grocery_item_id, :order_id])
+    params.require([:quantity, :grocery_item_id, :order_id])
   end
 end

--- a/db/migrate/20200327215526_add_user_id_to_grocery_items.rb
+++ b/db/migrate/20200327215526_add_user_id_to_grocery_items.rb
@@ -1,0 +1,5 @@
+class AddUserIdToGroceryItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :grocery_items, :user_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_190842) do
+ActiveRecord::Schema.define(version: 2020_03_27_215526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_190842) do
     t.float "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "user_id"
   end
 
   create_table "order_line_items", force: :cascade do |t|


### PR DESCRIPTION
This adds support for user created groceries. It does the following:

1. Adds a `user_id` to the groceries table

This makes it so that groceries can be attached to a user, and also makes it really easy for users to see all of the groceries they added

2. Adds GroceryItemsController#create with support for creating multiple

3. Makes it so that, on order creation, newly added grocery items are created in rails.
