### PR TITLE
Clean up layout on groceries page

### DIFF
--- a/app/javascript/components/Groceries/Groceries.tsx
+++ b/app/javascript/components/Groceries/Groceries.tsx
@@ -178,7 +178,7 @@ class Groceries extends React.Component<GroceriesProps, GroceriesState> {
             <Col><h3 className="text-center">{t('groceries.basket')}</h3></Col>
           </Row>
           <Row>
-            <Col>
+            <Col sm={12} md={6}>
               <GroceryList
                 items={this.state.searchLineItems}
                 handleAddButtonPressed={this.addItemToCart}
@@ -187,7 +187,7 @@ class Groceries extends React.Component<GroceriesProps, GroceriesState> {
                 maxQuantityPerItem={this.getMaxQuantity()}
               />
             </Col>
-            <Col>
+            <Col sm={12} md={6}>
               <Basket
                 items={this.state.cartLineItems}
                 handleRemovedButtonPressed={this.removeItemFromCart}

--- a/app/javascript/components/Groceries/components/Basket.tsx
+++ b/app/javascript/components/Groceries/components/Basket.tsx
@@ -23,12 +23,16 @@ class Basket extends React.Component<BasketProps & WithTranslation> {
   render(): JSX.Element {
     const { t } = this.props;
 
-    const headers = <Row>
-      <Col><h5>{t("basket.item")}</h5></Col>
-      <Col><h5>{t("basket.price")}</h5></Col>
-      <Col><h5>{t("basket.quantity")}</h5></Col>
-      <Col></Col>
-    </Row>
+    const headers = (
+      <ListGroup.Item>
+        <Row>
+          <Col><h6>{t("basket.item")}</h6></Col>
+          <Col><h6>{t("basket.price")}</h6></Col>
+          <Col><h6>{t("basket.quantity")}</h6></Col>
+          <Col></Col>
+        </Row>
+      </ListGroup.Item>
+    );
 
     const itemsList = this.props.items.map((item) =>
       <ListGroup.Item key={item.id}>
@@ -47,8 +51,8 @@ class Basket extends React.Component<BasketProps & WithTranslation> {
 
     return (
       <>
-        {headers}
-        <ListGroup>
+        <ListGroup variant="flush">
+          {headers}
           {itemsList}
           {this.getTotalPriceElement()}
           <ListGroup.Item>

--- a/app/javascript/components/Groceries/components/GroceryList.tsx
+++ b/app/javascript/components/Groceries/components/GroceryList.tsx
@@ -59,13 +59,15 @@ class GroceryList extends React.Component<GroceryListPropsWithI18n, GroceryListS
     } = this.props
 
     const headers = (
-      <Row>
-        <Col><h5>{t('grocery_list.item')}</h5></Col>
-        <Col><h5>{t('grocery_list.price')}</h5></Col>
-        <Col><h5>{t('grocery_list.quantity')}</h5></Col>
-        <Col></Col>
-      </Row>
-    )
+      <ListGroup.Item>
+        <Row>
+          <Col><h6>{t('grocery_list.item')}</h6></Col>
+          <Col><h6>{t('grocery_list.price')}</h6></Col>
+          <Col><h6>{t('grocery_list.quantity')}</h6></Col>
+          <Col></Col>
+        </Row>
+      </ListGroup.Item>
+    );
 
     const itemsList = items.map((item) =>
       <ListGroup.Item key={item.id}>
@@ -84,8 +86,8 @@ class GroceryList extends React.Component<GroceryListPropsWithI18n, GroceryListS
 
     return (
       <>
-        {headers}
-        <ListGroup>
+        <ListGroup variant="flush">
+          {headers}
           {itemsList}
           <ListGroup.Item>
             <p className="text-center">{t('grocery_list.search_prompt')}</p>


### PR DESCRIPTION
This cleans up the layout. It sets the variant of the `ListGroup` to `flush` so that it looks cleaner.

It also moves the headings inside of the `ListGroup` so it is cleaner.

Finally, it adds some breakpoints so that it collapses nicely for a small screen.