### PR TITLE
Create different order pages for different states

### DIFF
--- a/app/javascript/components/Order/components/ConfirmedOrderPage.tsx
+++ b/app/javascript/components/Order/components/ConfirmedOrderPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ConfirmedOrderPage(): JSX.Element {
+    return (<p>Order confirmed!</p>);
+}
+
+export default ConfirmedOrderPage;

--- a/app/javascript/components/Order/components/OrderDeliveryForm.tsx
+++ b/app/javascript/components/Order/components/OrderDeliveryForm.tsx
@@ -25,10 +25,14 @@ function getFormElement(fieldTitle: string): JSX.Element {
     );
 }
 
-function OrderDeliveryForm(): JSX.Element {
+interface OrderDeliveryFormProps {
+    onSubmit: () => void;
+}
+
+function OrderDeliveryForm(props: OrderDeliveryFormProps): JSX.Element {
     return (
         <>
-            <Form>
+            <Form onSubmit={props.onSubmit}>
                 {getFormElement('first_name')}
                 {getFormElement('phone_number')}
                 {getFormElement('address')}

--- a/app/javascript/components/Order/components/UnconfirmedOrderPage.tsx
+++ b/app/javascript/components/Order/components/UnconfirmedOrderPage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Row, Col, Container } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next';
+import { OrderItemList, OrderDeliveryForm } from './'
+
+interface OrderLineItem {
+    id: string;
+    quantity: number;
+    groceryItem: GroceryItem;
+}
+
+interface GroceryItem {
+    id: string;
+    name: string;
+    image: string;
+    price: number;
+}
+
+interface UnconfirmedOrderPageProps {
+    orderLineItems: OrderLineItem[];
+    onSubmit: () => void;
+}
+
+function UnconfirmedOrderPage(props: UnconfirmedOrderPageProps): JSX.Element {
+    const { t } = useTranslation();
+
+    return (
+        <Container>
+            <Row className="mt-4">
+                <Col xs={12} md={6}>
+                    <h3
+                        className='text-center'
+                    >
+                        {t('order.order_summary')}
+                    </h3>
+                    <OrderItemList
+                        OrderListItems={props.orderLineItems}
+                    />
+                </Col>
+                <Col xs={12} md={6}>
+                    <h3
+                        className='text-center'
+                    >
+                        {t('order.delivery_details')}
+                    </h3>
+                    <OrderDeliveryForm onSubmit={props.onSubmit} />
+                </Col>
+            </Row>
+        </Container>
+    );
+}
+
+export default UnconfirmedOrderPage;

--- a/app/javascript/components/Order/components/index.ts
+++ b/app/javascript/components/Order/components/index.ts
@@ -1,3 +1,5 @@
 export { default as OrderItem } from './OrderItem';
 export { default as OrderItemList } from './OrderItemList';
 export { default as OrderDeliveryForm } from './OrderDeliveryForm';
+export { default as UnconfirmedOrderPage } from './UnconfirmedOrderPage';
+export { default as ConfirmedOrderPage } from './ConfirmedOrderPage';


### PR DESCRIPTION
The `Order.tsx` component will be split up into different components, depending on the status of the order. This will allow the same url to point to the same order, even if the meanings are different (and not require different ways of getting there.

