### PR TITLE
Add errors for sign in and sign up (only on submit)

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::SessionsController < Devise::SessionsController
 
   def invalid_login_attempt
     warden.custom_failure!
-    render json: {error: 'invalid login attempt'}, status: :unprocessable_entity
+    render json: {errors: {invalid_login: true}}, status: :unprocessable_entity
   end
 
   def user_params

--- a/app/javascript/components/Users/components/SignUpCard.tsx
+++ b/app/javascript/components/Users/components/SignUpCard.tsx
@@ -1,22 +1,49 @@
 import React, { useState, useContext } from 'react';
-import { Button, Card, Form } from 'react-bootstrap';
+import { Button, Card, Form, Alert } from 'react-bootstrap';
 import { Redirect } from 'react-router-dom';
 import { UserContext } from '../../UserContext';
 import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
+
+interface SignUpErrors {
+    emailInvalid: boolean;
+    emailTaken: boolean;
+    passwordTooShort: boolean;
+    passwordMismatch: boolean;
+}
 
 interface User {
     email: string;
     password: string;
+    confirmedPassword: string;
     name: string;
 }
 
-function submitForm(event: React.FormEvent<HTMLFormElement>, user: User, setRedirect: (val: boolean) => void, setUser: (val: string) => void): void {
+interface SignUpResponse {
+    name: string;
+    errors?: { email?: string[]; password?: string[] };
+}
+
+function submitForm(
+    event: React.FormEvent<HTMLFormElement>,
+    user: User,
+    setRedirect: (val: boolean) => void,
+    setUser: (val: string) => void,
+    setErrors: (errors: SignUpErrors) => void,
+    errors: SignUpErrors,
+): void {
     event.preventDefault()
+    setErrors({ emailInvalid: false, emailTaken: false, passwordTooShort: false, passwordMismatch: false })
+
+    if (user.confirmedPassword !== user.password) {
+        setErrors({ ...errors, passwordMismatch: true });
+        return;
+    }
 
     const usersUrl = "/users";
     const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content") || "";
 
-    const signUpBody = { user: { ...user } }
+    const signUpBody = { user: { email: user.email, password: user.password, name: user.name } }
 
     const params = {
         method: "POST",
@@ -28,13 +55,24 @@ function submitForm(event: React.FormEvent<HTMLFormElement>, user: User, setRedi
     }
 
     fetch(usersUrl, params).then((response: Response) => {
-        if (response.ok) {
-            return response.json() as Promise<{ name: string }>;
+        if (response.ok || response.status == 422) {
+            return response.json() as Promise<SignUpResponse>;
         }
         throw new Error("Network response was not ok on user create.");
     }).then((response): void => {
-        setUser(response.name)
-        setRedirect(true)
+        if (response.errors) {
+            setErrors(
+                {
+                    passwordMismatch: false,
+                    emailInvalid: Boolean(response.errors?.email && response.errors?.email.includes("is invalid")),
+                    emailTaken: Boolean(response.errors?.email && response.errors?.email.includes("has already been taken")),
+                    passwordTooShort: Boolean(response.errors?.password && response.errors?.password.some((p) => p.includes("is too short") || p.includes("can't be blank")))
+                }
+            )
+        } else {
+            setUser(response.name)
+            setRedirect(true)
+        }
     })
 }
 
@@ -46,6 +84,25 @@ function renderRedirect(redirect: boolean): JSX.Element | null {
     return null
 }
 
+function getAlert(text: string): JSX.Element {
+    return <Alert variant="danger">{text}</Alert>
+}
+
+function renderErrorsAlert(errors: SignUpErrors, t: TFunction): JSX.Element | null {
+    if (errors.passwordMismatch) {
+        return getAlert(t('sign_up_card.password_mismatch'))
+    } else if (errors.emailInvalid) {
+        return getAlert(t('sign_up_card.email_invalid'))
+    } else if (errors.emailTaken) {
+        return getAlert(t('sign_up_card.email_in_use'))
+    } else if (errors.passwordTooShort) {
+        return getAlert(t('sign_up_card.password_too_short'))
+    } else {
+        return null;
+    }
+}
+
+
 function SignUpCard(): JSX.Element {
     const { t } = useTranslation();
     const userContext = useContext(UserContext);
@@ -54,6 +111,7 @@ function SignUpCard(): JSX.Element {
     const [confirmedPassword, setConfirmedPassword] = useState('');
     const [name, setName] = useState('');
     const [redirect, setRedirect] = useState(false);
+    const [errors, setErrors] = useState<SignUpErrors>({ emailInvalid: false, emailTaken: false, passwordTooShort: false, passwordMismatch: false })
 
     return (
         <div>
@@ -63,7 +121,17 @@ function SignUpCard(): JSX.Element {
                     <Card.Title style={{ textAlign: "center" }}>{t('sign_up_card.welcome')}</Card.Title>
                     <Card.Text className="text-muted" style={{ textAlign: "center" }}>{t('sign_up_card.getting_started')}</Card.Text>
                     <hr />
-                    <Form onSubmit={(event: React.FormEvent<HTMLFormElement>): void => submitForm(event, { email, password, name }, setRedirect, userContext.setUser)}>
+                    {renderErrorsAlert(errors, t)}
+                    <Form onSubmit={
+                        (event: React.FormEvent<HTMLFormElement>): void => submitForm(
+                            event,
+                            { email, password, confirmedPassword, name },
+                            setRedirect,
+                            userContext.setUser,
+                            setErrors,
+                            errors
+                        )
+                    }>
                         <Form.Group>
                             <Form.Label>{t('shared.email')}</Form.Label>
                             <Form.Control

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -94,7 +94,8 @@
         },
         "sign_in_card": {
             "welcome_back": "Welcome back! Enter your information below to sign into your account.",
-            "sign_in": "Sign in"
+            "sign_in": "Sign in",
+            "invalid_login": "The email and password combination you have entered is not valid."
         },
         "sign_up_card": {
             "welcome": "Welcome to GoGetGroceries",
@@ -102,7 +103,11 @@
             "password_criteria": "At least 6 characters long",
             "confirm_password": "Confirm Password",
             "name": "Name",
-            "create_account": "Create Account"
+            "create_account": "Create Account",
+            "email_in_use": "That email is already in use. Please go to the sign in page and use it to sign into your account.",
+            "email_invalid": "The entered email is invalid. Please double-check your email.",
+            "password_too_short": "The entered password is too short. Please make sure it is at least 6 characters.",
+            "password_mismatch": "The two passwords entered do not match. Please try entering your desired password again."
         },
         "shared": {
             "log_in": "Log in",


### PR DESCRIPTION
This adds errors to the sign in/up page. 

These pages also need real-time validation (E.g. password too short, mismatch, blank fields), because otherwise the experience is worse.